### PR TITLE
Fix build error with strlen in image_type_recognition

### DIFF
--- a/src/image_type_recognition/image_type_recognition_lite.cc
+++ b/src/image_type_recognition/image_type_recognition_lite.cc
@@ -206,12 +206,12 @@ class ArwTypeChecker : public TypeChecker {
 class Cr3TypeChecker : public TypeChecker {
  public:
   static constexpr size_t kSignatureOffset = 4;
-  static constexpr const char* kSignature = "ftypcrx ";
+  static constexpr const char kSignature[] = "ftypcrx ";
 
   virtual RawImageTypes Type() const { return kCr3Image; }
 
   virtual size_t RequestedSize() const {
-    return kSignatureOffset + strlen(kSignature);
+    return kSignatureOffset + std::size(kSignature) - 1;
   }
 
   // Checks for the ftyp box w/ brand 'crx '.


### PR DESCRIPTION
The following pull request fixes a build error attempting to do a standalone build of piex due to strlen not being available.